### PR TITLE
discard query string for requests to other pages than the search page

### DIFF
--- a/apache/config/000-default.conf
+++ b/apache/config/000-default.conf
@@ -1,24 +1,24 @@
 <VirtualHost *:80>
-	# The ServerName directive sets the request scheme, hostname and port that
-	# the server uses to identify itself. This is used when creating
-	# redirection URLs. In the context of virtual hosts, the ServerName
-	# specifies what hostname must appear in the request's Host: header to
-	# match this virtual host. For the default virtual host (this file) this
-	# value is not decisive as it is used as a last resort host regardless.
-	# However, you must set it for any further virtual host explicitly.
-	ServerName vmcp-editorial.rbg.vic.gov.au
+        # The ServerName directive sets the request scheme, hostname and port that
+        # the server uses to identify itself. This is used when creating
+        # redirection URLs. In the context of virtual hosts, the ServerName
+        # specifies what hostname must appear in the request's Host: header to
+        # match this virtual host. For the default virtual host (this file) this
+        # value is not decisive as it is used as a last resort host regardless.
+        # However, you must set it for any further virtual host explicitly.
+        ServerName vmcp-editorial.rbg.vic.gov.au
 
-	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/html
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/html
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
 
-	ErrorLog ${APACHE_LOG_DIR}/error.log
-	CustomLog ${APACHE_LOG_DIR}/access.log combined
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
 
 # users must authenticate to view any of the data
 <Location "/">
@@ -43,12 +43,12 @@ IndexOptions XHTML
 </Directory>
 ProxyPass "/xtf/" "http://localhost:8080/xtf/"
 ProxyPassReverse "/xtf/" "http://localhost:8080/xtf/"
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
+        # For most configuration files from conf-available/, which are
+        # enabled or disabled at a global level, it is possible to
+        # include a line for only one particular virtual host. For example the
+        # following line enables the CGI configuration for this host only
+        # after it has been globally disabled with "a2disconf".
+        #Include conf-available/serve-cgi-bin.conf
 </VirtualHost>
 
 <VirtualHost *:80>
@@ -57,6 +57,10 @@ ProxyPassReverse "/xtf/" "http://localhost:8080/xtf/"
     DocumentRoot /var/www/vmcp
 
     RewriteEngine On
+    RewriteCond %{QUERY_STRING} .
+    RewriteCond %{REQUEST_URI} !^/search
+    RewriteRule ^(.*)$ $1 [R=301,QSD]
+
     RewriteCond %{REQUEST_URI} !^/$
     RewriteCond %{REQUEST_URI} !^/id/
     RewriteCond %{REQUEST_URI} !^/search


### PR DESCRIPTION
- RBGV website adds GA token in query string, which results in a 404 error.